### PR TITLE
fixed error in retain config

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -41,7 +41,7 @@ const (
 	defMqttMTLS       = "false"
 	defMqttCA         = "ca.crt"
 	defMqttQoS        = "0"
-	defMqttRetain     = false
+	defMqttRetain     = "false"
 	defMqttCert       = "thing.cert"
 	defMqttPrivKey    = "thing.key"
 	defConfigFile     = "../configs/config.toml"
@@ -141,7 +141,7 @@ func loadConfigs() (exp.Config, error) {
 		if err != nil {
 			mqttMTLS = false
 		}
-		mqttRetain, err := strconv.ParseBool(mainflux.Env(envMqttMTLS, defMqttMTLS))
+		mqttRetain, err := strconv.ParseBool(mainflux.Env(envMqttRetain, defMqttRetain))
 		if err != nil {
 			mqttRetain = false
 		}


### PR DESCRIPTION
Fixed error in config reading. 
When configuration loaded from env, the retain param was filled with "envMqttMTLS" instead of "envMqttRetain"

Signed-off-by: PricelessRabbit <PricelessRabbit@gmail.com>