### PR TITLE
MF-29 - goroutine in some cases never process channel messages

### DIFF
--- a/pkg/export/route.go
+++ b/pkg/export/route.go
@@ -83,7 +83,7 @@ func (r *Route) Process(data []byte) ([]byte, error) {
 
 }
 
-func (r *Route) Consume() {
+func (r Route) Consume() {
 	for msg := range r.Messages {
 		payload, err := r.Process(msg.Data)
 		if err != nil {

--- a/pkg/export/route.go
+++ b/pkg/export/route.go
@@ -48,12 +48,12 @@ type Route struct {
 	pub       messages.Publisher
 }
 
-func NewRoute(rc config.Route, log logger.Logger, pub messages.Publisher) Route {
+func NewRoute(rc config.Route, log logger.Logger, pub messages.Publisher) *Route {
 	w := rc.Workers
 	if w == 0 {
 		w = workers
 	}
-	r := Route{
+	r := &Route{
 		NatsTopic: rc.NatsTopic + "." + NatsAll,
 		MqttTopic: rc.MqttTopic,
 		Subtopic:  rc.SubTopic,
@@ -83,7 +83,7 @@ func (r *Route) Process(data []byte) ([]byte, error) {
 
 }
 
-func (r Route) Consume() {
+func (r *Route) Consume() {
 	for msg := range r.Messages {
 		payload, err := r.Process(msg.Data)
 		if err != nil {

--- a/pkg/export/service.go
+++ b/pkg/export/service.go
@@ -39,7 +39,7 @@ type exporter struct {
 	id        string
 	mqtt      mqtt.Client
 	cfg       config.Config
-	consumers map[string]Route
+	consumers map[string]*Route
 	logger    logger.Logger
 	connected chan bool
 	status    uint32
@@ -62,7 +62,7 @@ var errNoRoutesConfigured = errors.New("No routes configured")
 
 // New create new instance of export service
 func New(c config.Config, l logger.Logger) (Service, error) {
-	routes := make(map[string]Route)
+	routes := make(map[string]*Route)
 	id := fmt.Sprintf("export-%s", c.MQTT.Username)
 
 	e := exporter{
@@ -81,7 +81,7 @@ func New(c config.Config, l logger.Logger) (Service, error) {
 
 // Start method loads route configuration
 func (e *exporter) Start(queue string) errors.Error {
-	var route Route
+	var route *Route
 	for _, r := range e.cfg.Routes {
 		route = e.newRoute(r)
 		if !e.validateSubject(route.NatsTopic) {
@@ -109,7 +109,7 @@ func (e *exporter) Logger() logger.Logger {
 	return e.logger
 }
 
-func (e *exporter) newRoute(r config.Route) Route {
+func (e *exporter) newRoute(r config.Route) *Route {
 	return NewRoute(r, e.logger, e)
 }
 


### PR DESCRIPTION
Fixed #29  :
reference type cause the route struct channel to be overwritten by the goroutine that subscribe the routes.
The `for := range` channel reference is changed if not already used  and consumer got stuck

Changed the Consume func receiver to value receiver. In this way each worker has owns a copy of route data

Signed-off-by: PricelessRabbit <PricelessRabbit@gmail.com>